### PR TITLE
Changed import statement and reference to GenericRelation in order

### DIFF
--- a/src/auditlog/middleware.py
+++ b/src/auditlog/middleware.py
@@ -6,7 +6,7 @@ import time
 from django.conf import settings
 from django.db.models.signals import pre_save
 from django.utils.functional import curry
-from django.db.models.loading import get_model
+from django.apps import apps
 from auditlog.models import LogEntry
 
 
@@ -65,9 +65,9 @@ class AuditlogMiddleware(object):
         """
         try:
             app_label, model_name = settings.AUTH_USER_MODEL.split('.')
-            auth_user_model = get_model(app_label, model_name)
+            auth_user_model = apps.get_model(app_label, model_name)
         except ValueError:
-            auth_user_model = get_model('auth', 'user')
+            auth_user_model = apps.get_model('auth', 'user')
         if sender == LogEntry and isinstance(user, auth_user_model) and instance.actor is None:
             instance.actor = user
         if hasattr(threadlocal, 'auditlog'):

--- a/src/auditlog/models.py
+++ b/src/auditlog/models.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import json
 
 from django.conf import settings
-from django.contrib.contenttypes import generic
+from django.contrib.contenttypes.fields import GenericRelation
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.db.models import QuerySet, Q
@@ -227,9 +227,9 @@ class LogEntry(models.Model):
         return separator.join(substrings)
 
 
-class AuditlogHistoryField(generic.GenericRelation):
+class AuditlogHistoryField(GenericRelation):
     """
-    A subclass of py:class:`django.contrib.contenttypes.generic.GenericRelation` that sets some default variables. This
+    A subclass of py:class:`django.contrib.contenttypes.fields.GenericRelation` that sets some default variables. This
     makes it easier to access Auditlog's log entries, for example in templates.
 
     By default this field will assume that your primary keys are numeric, simply because this is the most common case.


### PR DESCRIPTION
to remove the following Django Warning:
> site-packages/auditlog/models.py:6: RemovedInDjango19Warning:
> django.contrib.contenttypes.generic is deprecated and will be removed in Django 1.9. Its contents have been moved to the fields, forms, and admin submodules of django.contrib.contenttypes.
> from django.contrib.contenttypes import generic