### PR TITLE
Add db_index to object_pk

### DIFF
--- a/src/auditlog/migrations/0005_logentry_additional_data_verbose_name.py
+++ b/src/auditlog/migrations/0005_logentry_additional_data_verbose_name.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import jsonfield.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('auditlog', '0004_logentry_detailed_object_repr'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='logentry',
+            name='additional_data',
+            field=jsonfield.fields.JSONField(null=True, verbose_name='additional data', blank=True),
+        ),
+    ]

--- a/src/auditlog/migrations/0006_object_pk_index.py
+++ b/src/auditlog/migrations/0006_object_pk_index.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('auditlog', '0005_logentry_additional_data_verbose_name'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='logentry',
+            name='object_pk',
+            field=models.TextField(verbose_name='object pk', db_index=True),
+        ),
+    ]

--- a/src/auditlog/models.py
+++ b/src/auditlog/models.py
@@ -160,7 +160,7 @@ class LogEntry(models.Model):
         )
 
     content_type = models.ForeignKey('contenttypes.ContentType', on_delete=models.CASCADE, related_name='+', verbose_name=_("content type"))
-    object_pk = models.TextField(verbose_name=_("object pk"), db_index=True)
+    object_pk = models.TextField(db_index=True, verbose_name=_("object pk"))
     object_id = models.BigIntegerField(blank=True, db_index=True, null=True, verbose_name=_("object id"))
     object_repr = models.TextField(verbose_name=_("object representation"))
     action = models.PositiveSmallIntegerField(choices=Action.choices, verbose_name=_("action"))

--- a/src/auditlog/models.py
+++ b/src/auditlog/models.py
@@ -160,7 +160,7 @@ class LogEntry(models.Model):
         )
 
     content_type = models.ForeignKey('contenttypes.ContentType', on_delete=models.CASCADE, related_name='+', verbose_name=_("content type"))
-    object_pk = models.TextField(verbose_name=_("object pk"))
+    object_pk = models.TextField(verbose_name=_("object pk"), db_index=True)
     object_id = models.BigIntegerField(blank=True, db_index=True, null=True, verbose_name=_("object id"))
     object_repr = models.TextField(verbose_name=_("object representation"))
     action = models.PositiveSmallIntegerField(choices=Action.choices, verbose_name=_("action"))


### PR DESCRIPTION
Was seeing a big hit on heroku because of object_pk not having an index. This seems to clean it up. The 0005 migration is happening automatically when I run makemigrations and doesnt really change anything.

