### PR TITLE
Change LogEntry.get_for_objects to distinguish between number and text keys.

### DIFF
--- a/src/auditlog/models.py
+++ b/src/auditlog/models.py
@@ -92,7 +92,11 @@ class LogEntryManager(models.Manager):
         content_type = ContentType.objects.get_for_model(queryset.model)
         primary_keys = queryset.values_list(queryset.model._meta.pk.name, flat=True)
 
-        return self.filter(content_type=content_type).filter(Q(object_id__in=primary_keys) | Q(object_pk__in=primary_keys)).distinct()
+        if isinstance(primary_keys[0], integer_types):
+            return self.filter(content_type=content_type).filter(Q(object_id__in=primary_keys)).distinct()
+        else:
+            return self.filter(content_type=content_type).filter(Q(object_pk__in=primary_keys)).distinct()
+
 
     def get_for_model(self, model):
         """


### PR DESCRIPTION
When using LogEntry.get_for_objects with a model that has an automatic (numeric) primary key, the following error occurs:
```
operator does not exist: text = integer LINE 1: ...ction_id" = 1) OR "auditlog_logentry"."object_pk" IN (SELECT... ^ HINT: No operator matches the given name and argument type(s). You might need to add explicit type casts.
```

I suspect this is a Postgres-specific error.