### PR TITLE
Updated Mixin to use get_full_name method

### DIFF
--- a/src/auditlog/mixins.py
+++ b/src/auditlog/mixins.py
@@ -17,7 +17,7 @@ class LogEntryAdminMixin(object):
             app_label, model = settings.AUTH_USER_MODEL.split('.')
             viewname = 'admin:%s_%s_change' % (app_label, model.lower())
             link = urlresolvers.reverse(viewname, args=[obj.actor.id])
-            return u'<a href="%s">%s</a>' % (link, obj.actor.full_name or obj.actor.email)
+            return u'<a href="%s">%s</a>' % (link, obj.actor.get_full_name() or obj.actor.email)
         return 'system'
     user_url.allow_tags = True
     user_url.short_description = 'User'


### PR DESCRIPTION
Updated LogEntryAdminMixin to use models.User.get_full_name() method for django 1.10.

https://docs.djangoproject.com/en/1.10/ref/contrib/auth/#django.contrib.auth.models.User.get_full_name