### PR TITLE
Properly check timezone-aware DateTimeFields for changes

### DIFF
--- a/src/auditlog_tests/models.py
+++ b/src/auditlog_tests/models.py
@@ -106,6 +106,18 @@ class AdditionalDataIncludedModel(models.Model):
         }
         return object_details
 
+
+class DateTimeFieldModel(models.Model):
+    """
+    A model with a DateTimeField, used to test DateTimeField
+    changes are detected properly.
+    """
+    label = models.CharField(max_length=100)
+    timestamp = models.DateTimeField()
+
+    history = AuditlogHistoryField()
+
+
 auditlog.register(SimpleModel)
 auditlog.register(AltPrimaryKeyModel)
 auditlog.register(ProxyModel)
@@ -115,3 +127,4 @@ auditlog.register(ManyRelatedModel.related.through)
 auditlog.register(SimpleIncludeModel, include_fields=['label'])
 auditlog.register(SimpleExcludeModel, exclude_fields=['text'])
 auditlog.register(AdditionalDataIncludedModel)
+auditlog.register(DateTimeFieldModel)

--- a/src/auditlog_tests/test_settings.py
+++ b/src/auditlog_tests/test_settings.py
@@ -24,3 +24,5 @@ DATABASES = {
 }
 
 ROOT_URLCONF = []
+
+USE_TZ = True


### PR DESCRIPTION
Django converts the timezone of DateTimeFields to UTC when the field gets saved, when you update a model which includes a DateTimeField, and your server is running in another timezone. This results in the AuditLog thinking you changed the timestamp, while it actually is the same time, but in another timezone.

This PR adds a specific check in the model_instance_diff function for DateTimeField models (and any subclasses of it), which converts the old and new values to UTC before comparing them to see if they've actually changed. It also adds tests to see if the code works properly. This fixes #82.

The extra test_setting (USE_TZ) is added because timezone support is disabled if it is not specified, this setting enables it.

DateFields are not timezone-aware, so they do not need fixing.