### PR TITLE
Fix the resource_url method when a model primary key is a models.UUIDField

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
+*.db
+*.egg-info
 *.log
 *.pot
 *.pyc
-*.db
-local_settings.py
-.pydevproject
+.idea
 .project
+.pydevproject
+local_settings.py

--- a/src/auditlog/mixins.py
+++ b/src/auditlog/mixins.py
@@ -25,7 +25,7 @@ class LogEntryAdminMixin(object):
     def resource_url(self, obj):
         app_label, model = obj.content_type.app_label, obj.content_type.model
         viewname = 'admin:%s_%s_change' % (app_label, model)
-        link = urlresolvers.reverse(viewname, args=[obj.object_id])
+        link = urlresolvers.reverse(viewname, args=[obj.object_id or obj.object_pk])
         return u'<a href="%s">%s</a>' % (link, obj.object_repr)
     resource_url.allow_tags = True
     resource_url.short_description = 'Resource'


### PR DESCRIPTION
- We need to consider use the object_pk in this case.
- Add *.egg-info and .idea (PyCharm files) to the .gitignore
- Sort lines in .gitignore file