### PR TITLE
Use make_naive only if settings.USE_TZ is True.

### DIFF
--- a/src/auditlog/diff.py
+++ b/src/auditlog/diff.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Model, NOT_PROVIDED, DateTimeField
 from django.utils import timezone
@@ -64,7 +65,7 @@ def get_field_value(obj, field):
         # to its naive form before we can accuratly compare them for changes.
         try:
             value = field.to_python(getattr(obj, field.name, None))
-            if value is not None:
+            if value is not None and settings.USE_TZ:
                 value = timezone.make_naive(value, timezone=timezone.utc)
         except ObjectDoesNotExist:
             value = field.default if field.default is not NOT_PROVIDED else None


### PR DESCRIPTION
My Django app is using the setting USE_TZ=False and it is throwing the following error:

<img width="849" alt="screen shot 2017-01-26 at 01 45 31" src="https://cloud.githubusercontent.com/assets/228895/22319500/6066b64c-e36a-11e6-8299-9415c9b45517.png">

<img width="712" alt="screen shot 2017-01-26 at 01 45 57" src="https://cloud.githubusercontent.com/assets/228895/22319502/6446b94c-e36a-11e6-9dbc-4d4e826a6a8b.png">

If I change the settings to True, it work like a charm (but I cant change it by now). We need to support applications that use this settings to False.

So, I added a verification to consider the timezone only if it is enable in the Django app.
