### PR TITLE
Support models with UUID primary keys

### DIFF
--- a/src/auditlog/models.py
+++ b/src/auditlog/models.py
@@ -75,7 +75,7 @@ class LogEntryManager(models.Manager):
         if isinstance(pk, integer_types):
             return self.filter(content_type=content_type, object_id=pk)
         else:
-            return self.filter(content_type=content_type, object_pk=pk)
+            return self.filter(content_type=content_type, object_pk=smart_text(pk))
 
     def get_for_objects(self, queryset):
         """
@@ -94,6 +94,9 @@ class LogEntryManager(models.Manager):
 
         if isinstance(primary_keys[0], integer_types):
             return self.filter(content_type=content_type).filter(Q(object_id__in=primary_keys)).distinct()
+        elif isinstance(queryset.model._meta.pk, models.UUIDField):
+            primary_keys = [smart_text(pk) for pk in primary_keys]
+            return self.filter(content_type=content_type).filter(Q(object_pk__in=primary_keys)).distinct()
         else:
             return self.filter(content_type=content_type).filter(Q(object_pk__in=primary_keys)).distinct()
 

--- a/src/auditlog/models.py
+++ b/src/auditlog/models.py
@@ -90,7 +90,7 @@ class LogEntryManager(models.Manager):
             return self.none()
 
         content_type = ContentType.objects.get_for_model(queryset.model)
-        primary_keys = queryset.values_list(queryset.model._meta.pk.name, flat=True)
+        primary_keys = list(queryset.values_list(queryset.model._meta.pk.name, flat=True))
 
         if isinstance(primary_keys[0], integer_types):
             return self.filter(content_type=content_type).filter(Q(object_id__in=primary_keys)).distinct()

--- a/src/auditlog_tests/models.py
+++ b/src/auditlog_tests/models.py
@@ -1,3 +1,5 @@
+import uuid
+
 from django.db import models
 from auditlog.models import AuditlogHistoryField
 from auditlog.registry import auditlog
@@ -23,6 +25,21 @@ class AltPrimaryKeyModel(models.Model):
     """
 
     key = models.CharField(max_length=100, primary_key=True)
+
+    text = models.TextField(blank=True)
+    boolean = models.BooleanField(default=False)
+    integer = models.IntegerField(blank=True, null=True)
+    datetime = models.DateTimeField(auto_now=True)
+
+    history = AuditlogHistoryField(pk_indexable=False)
+
+
+class UUIDPrimaryKeyModel(models.Model):
+    """
+    A model with a UUID primary key.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
 
     text = models.TextField(blank=True)
     boolean = models.BooleanField(default=False)
@@ -121,6 +138,7 @@ class DateTimeFieldModel(models.Model):
 
 
 auditlog.register(AltPrimaryKeyModel)
+auditlog.register(UUIDPrimaryKeyModel)
 auditlog.register(ProxyModel)
 auditlog.register(RelatedModel)
 auditlog.register(ManyRelatedModel)

--- a/src/auditlog_tests/tests.py
+++ b/src/auditlog_tests/tests.py
@@ -9,9 +9,9 @@ from django.utils import timezone
 from auditlog.middleware import AuditlogMiddleware
 from auditlog.models import LogEntry
 from auditlog.registry import auditlog
-from auditlog_tests.models import SimpleModel, AltPrimaryKeyModel, ProxyModel, \
-    SimpleIncludeModel, SimpleExcludeModel, RelatedModel, ManyRelatedModel, AdditionalDataIncludedModel, \
-    DateTimeFieldModel
+from auditlog_tests.models import SimpleModel, AltPrimaryKeyModel, UUIDPrimaryKeyModel, \
+    ProxyModel, SimpleIncludeModel, SimpleExcludeModel, RelatedModel, ManyRelatedModel, \
+    AdditionalDataIncludedModel, DateTimeFieldModel
 
 
 class SimpleModelTest(TestCase):
@@ -72,6 +72,23 @@ class SimpleModelTest(TestCase):
 class AltPrimaryKeyModelTest(SimpleModelTest):
     def setUp(self):
         self.obj = AltPrimaryKeyModel.objects.create(key=str(datetime.datetime.now()), text='I am strange.')
+
+
+class UUIDPrimaryKeyModelModelTest(SimpleModelTest):
+    def setUp(self):
+        self.obj = UUIDPrimaryKeyModel.objects.create(text='I am strange.')
+
+    def test_get_for_object(self):
+        self.obj.boolean = True
+        self.obj.save()
+
+        self.assertEqual(LogEntry.objects.get_for_object(self.obj).count(), 2)
+
+    def test_get_for_objects(self):
+        self.obj.boolean = True
+        self.obj.save()
+
+        self.assertEqual(LogEntry.objects.get_for_objects(UUIDPrimaryKeyModel.objects.all()).count(), 2)
 
 
 class ProxyModelTest(SimpleModelTest):


### PR DESCRIPTION
This PR adds support for models with primary keys that use Django's UUIDField.

Fixes #110 