### PR TITLE
Add management commands package to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 setup(
     name='django-auditlog',
     version='0.4.3',
-    packages=['auditlog', 'auditlog.migrations'],
+    packages=['auditlog', 'auditlog.migrations', 'auditlog.management', 'auditlog.management.commands'],
     package_dir={'': 'src'},
     url='https://github.com/jjkester/django-auditlog',
     license='MIT',


### PR DESCRIPTION
We weren't actually packaging up the management command when we published to PyPI, fixes #129 