### PR TITLE
(bugfix) changes_display_dict errors

### DIFF
--- a/src/auditlog/models.py
+++ b/src/auditlog/models.py
@@ -9,12 +9,11 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import FieldDoesNotExist
 from django.db import models
 from django.db.models import QuerySet, Q
-from django.utils import formats
+from django.utils import formats, timezone
 from django.utils.encoding import python_2_unicode_compatible, smart_text
 from django.utils.six import iteritems, integer_types
 from django.utils.translation import ugettext_lazy as _
 
-import pytz
 from jsonfield.fields import JSONField
 from dateutil import parser
 from dateutil.tz import gettz
@@ -293,7 +292,7 @@ class LogEntry(models.Model):
                             elif field_type == "TimeField":
                                 value = value.time()
                             elif field_type == "DateTimeField":
-                                value = value.replace(tzinfo=pytz.utc)
+                                value = value.replace(tzinfo=timezone.utc)
                                 value = value.astimezone(gettz(settings.TIME_ZONE))
                             value = formats.localize(value)
                         except ValueError:

--- a/src/auditlog/models.py
+++ b/src/auditlog/models.py
@@ -302,8 +302,7 @@ class LogEntry(models.Model):
                         value = "{}...".format(value[:140])
 
                     values_display.append(value)
-            verbose_name = model_fields['mapping_fields'].get(
-                field.name, hasattr(field, 'verbose_name') and field.verbose_name or field.name)
+            verbose_name = model_fields['mapping_fields'].get(field.name, getattr(field, 'verbose_name', field.name))
             changes_display_dict[verbose_name] = values_display
         return changes_display_dict
 

--- a/src/auditlog/models.py
+++ b/src/auditlog/models.py
@@ -259,9 +259,9 @@ class LogEntry(models.Model):
             values_display = []
             # handle choices fields and Postgres ArrayField to get human readable version
             choices_dict = None
-            if hasattr(field, 'choices'):
+            if hasattr(field, 'choices') and len(field.choices) > 0:
                 choices_dict = dict(field.choices)
-            elif  hasattr(field, 'base_field') and getattr(field.base_field, 'choices', False):
+            if hasattr(field, 'base_field') and getattr(field.base_field, 'choices', False):
                 choices_dict = dict(field.base_field.choices)
 
             if choices_dict:

--- a/src/auditlog/models.py
+++ b/src/auditlog/models.py
@@ -259,8 +259,13 @@ class LogEntry(models.Model):
                 continue
             values_display = []
             # handle choices fields and Postgres ArrayField to get human readable version
-            if field.choices or hasattr(field, 'base_field') and getattr(field.base_field, 'choices', False):
-                choices_dict = dict(field.choices or field.base_field.choices)
+            choices_dict = None
+            if hasattr(field, 'choices'):
+                choices_dict = dict(field.choices)
+            elif  hasattr(field, 'base_field') and getattr(field.base_field, 'choices', False):
+                choices_dict = dict(field.base_field.choices)
+
+            if choices_dict:
                 for value in values:
                     try:
                         value = ast.literal_eval(value)

--- a/src/auditlog/models.py
+++ b/src/auditlog/models.py
@@ -14,8 +14,10 @@ from django.utils.encoding import python_2_unicode_compatible, smart_text
 from django.utils.six import iteritems, integer_types
 from django.utils.translation import ugettext_lazy as _
 
+import pytz
 from jsonfield.fields import JSONField
 from dateutil import parser
+from dateutil.tz import gettz
 
 
 class LogEntryManager(models.Manager):
@@ -281,6 +283,9 @@ class LogEntry(models.Model):
                                 value = value.date()
                             elif field_type == "TimeField":
                                 value = value.time()
+                            elif field_type == "DateTimeField":
+                                value = value.replace(tzinfo=pytz.utc)
+                                value = value.astimezone(gettz(settings.TIME_ZONE))
                             value = formats.localize(value)
                         except ValueError:
                             pass

--- a/src/auditlog/models.py
+++ b/src/auditlog/models.py
@@ -302,7 +302,8 @@ class LogEntry(models.Model):
                         value = "{}...".format(value[:140])
 
                     values_display.append(value)
-            verbose_name = model_fields['mapping_fields'].get(field.name, field.verbose_name)
+            verbose_name = model_fields['mapping_fields'].get(
+                field.name, hasattr(field, 'verbose_name') and field.verbose_name or field.name)
             changes_display_dict[verbose_name] = values_display
         return changes_display_dict
 

--- a/src/auditlog/models.py
+++ b/src/auditlog/models.py
@@ -278,7 +278,11 @@ class LogEntry(models.Model):
                     except:
                         values_display.append(choices_dict.get(value, 'None'))
             else:
-                field_type = field.get_internal_type()
+                try:
+                    field_type = field.get_internal_type()
+                except AttributeError:
+                    # if the field is a relationship it has no internal type and exclude it
+                    continue
                 for value in values:
                     # handle case where field is a datetime, date, or time type
                     if field_type in ["DateTimeField", "DateField", "TimeField"]:

--- a/src/auditlog_tests/tests.py
+++ b/src/auditlog_tests/tests.py
@@ -6,6 +6,7 @@ from django.db.models.signals import pre_save
 from django.http import HttpResponse
 from django.test import TestCase, RequestFactory
 from django.utils import dateformat, formats, timezone
+from dateutil.tz import gettz
 
 from auditlog.middleware import AuditlogMiddleware
 from auditlog.models import LogEntry
@@ -371,22 +372,24 @@ class DateTimeFieldModelTest(TestCase):
         time = datetime.time(12, 0)
         dtm = DateTimeFieldModel(label='DateTimeField model', timestamp=timestamp, date=date, time=time)
         dtm.save()
+        localized_timestamp = timestamp.astimezone(gettz(settings.TIME_ZONE))
         self.assertTrue(dtm.history.latest().changes_display_dict["timestamp"][1] == \
-                        dateformat.format(timestamp, settings.DATETIME_FORMAT),
+                        dateformat.format(localized_timestamp, settings.DATETIME_FORMAT),
                         msg=("The datetime should be formatted according to Django's settings for"
                              " DATETIME_FORMAT"))
         timestamp = timezone.now()
         dtm.timestamp = timestamp
         dtm.save()
+        localized_timestamp = timestamp.astimezone(gettz(settings.TIME_ZONE))
         self.assertTrue(dtm.history.latest().changes_display_dict["timestamp"][1] == \
-                        dateformat.format(timestamp, settings.DATETIME_FORMAT),
+                        dateformat.format(localized_timestamp, settings.DATETIME_FORMAT),
                         msg=("The datetime should be formatted according to Django's settings for"
                              " DATETIME_FORMAT"))
 
         # Change USE_L10N = True
         with self.settings(USE_L10N=True, LANGUAGE_CODE='en-GB'):
             self.assertTrue(dtm.history.latest().changes_display_dict["timestamp"][1] == \
-                        formats.localize(timestamp),
+                        formats.localize(localized_timestamp),
                         msg=("The datetime should be formatted according to Django's settings for"
                              " USE_L10N is True with a different LANGUAGE_CODE."))
 


### PR DESCRIPTION
Found some bugs with my previous pr to add `changes_display_dict` property.

This PR Fixes four bugs discovered with changes_display_dict, three that caused crashes and the other was datetimes being displayed in UTC instead of the servers set timezone.
  
  