### PR TITLE
Fixed deprecation warnings showing up in Django 1.11

### DIFF
--- a/src/auditlog/compat.py
+++ b/src/auditlog/compat.py
@@ -1,4 +1,5 @@
 import django
+import inspect
 
 def is_authenticated(user):
     """Return whether or not a User is authenticated.
@@ -10,8 +11,8 @@ def is_authenticated(user):
     as `is_authenticated` was introduced as a property in v1.10.s
     """
     if not hasattr(user, 'is_authenticated'):
-       return False
-    if callable(user.is_authenticated):
+        return False
+    if inspect.ismethod(user.is_authenticated):
         # Will be callable if django.version < 2.0, but is only necessary in
         # v1.9 and earlier due to change introduced in v1.10 making
         # `is_authenticated` a property instead of a callable.

--- a/src/auditlog/diff.py
+++ b/src/auditlog/diff.py
@@ -24,12 +24,14 @@ def track_field(field):
         return False
 
     # Do not track relations to LogEntry
-    if getattr(field, 'remote_field', None) is not None and field.remote_field.model == LogEntry:
-        return False
+    if hasattr(field, 'remote_field'):
+        if getattr(field, 'remote_field', None) is not None and field.remote_field.model == LogEntry:
+            return False
 
     # 1.8 check
-    elif getattr(field, 'rel', None) is not None and field.rel.to == LogEntry:
-        return False
+    elif 'rel' in dir(field) and getattr(field, 'rel', None) is not None:
+        if field.rel.to == LogEntry:
+            return False
 
     return True
 

--- a/src/auditlog/diff.py
+++ b/src/auditlog/diff.py
@@ -25,13 +25,12 @@ def track_field(field):
 
     # Do not track relations to LogEntry
     if hasattr(field, 'remote_field'):
-        if getattr(field, 'remote_field', None) is not None and field.remote_field.model == LogEntry:
+        if field.remote_field is not None and field.remote_field.model == LogEntry:
             return False
 
     # 1.8 check
-    elif 'rel' in dir(field) and getattr(field, 'rel', None) is not None:
-        if field.rel.to == LogEntry:
-            return False
+    elif getattr(field, 'rel', None) is not None and field.rel.to == LogEntry:
+        return False
 
     return True
 


### PR DESCRIPTION
The backwards compatible code in diff.py and compat.py were still giving DeprecationWarnings in Django 1.11. I fixed the code so it won't call/reference the deprecated functions/properties. 

This PR fixes this issue here: https://github.com/jjkester/django-auditlog/issues/116
