### PR TITLE
Configurable Logger Backend

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,3 +5,4 @@ tox>=1.7.0
 codecov>=2.0.0
 django-multiselectfield==0.1.8
 psycopg2
+mock

--- a/src/auditlog/backends/__init__.py
+++ b/src/auditlog/backends/__init__.py
@@ -1,0 +1,11 @@
+from django.utils.module_loading import import_string
+
+from auditlog import settings
+
+
+def get_audit_backend():
+    """Returns an instantiated audit backend class"""
+    return import_string(settings.AUDITLOG_BACKEND)()
+
+
+auditlog_backend = get_audit_backend()

--- a/src/auditlog/backends/base.py
+++ b/src/auditlog/backends/base.py
@@ -10,7 +10,7 @@ class AuditBackend(object):
         if created:
             changes = model_instance_diff(None, instance)
 
-            self.create_log(
+            self.create_log_entry(
                 instance=instance,
                 action=LogEntry.Action.CREATE,
                 changes=changes,
@@ -30,7 +30,7 @@ class AuditBackend(object):
 
                 # Log an entry only if there are changes
                 if changes:
-                    self.create_log(
+                    self.create_log_entry(
                         instance=instance,
                         action=LogEntry.Action.UPDATE,
                         changes=changes,
@@ -41,11 +41,11 @@ class AuditBackend(object):
         if instance.pk is not None:
             changes = model_instance_diff(instance, None)
 
-            self.create_log(
+            self.create_log_entry(
                 instance=instance,
                 action=LogEntry.Action.DELETE,
                 changes=changes,
                 **kwargs)
 
-    def create_log(self, action, instance, changes, **kwargs):
+    def create_log_entry(self, action, instance, changes, **kwargs):
         raise NotImplemented('Backend must implement a log create method')

--- a/src/auditlog/backends/base.py
+++ b/src/auditlog/backends/base.py
@@ -1,0 +1,51 @@
+from auditlog.diff import model_instance_diff
+from auditlog.models import LogEntry
+
+
+class AuditBackend(object):
+    """Base backend for creation of audit log entries."""
+
+    def log_create(self, instance, created, **kwargs):
+        """Handle model creation logging"""
+        if created:
+            changes = model_instance_diff(None, instance)
+
+            self.create_log(
+                instance=instance,
+                action=LogEntry.Action.CREATE,
+                changes=changes,
+                **kwargs)
+
+    def log_update(self, instance, **kwargs):
+        """Handle model update logging"""
+        if instance.pk is not None:
+            try:
+                old = instance.__class__.objects.get(pk=instance.pk)
+            except instance.__class__.DoesNotExist:
+                pass
+            else:
+                new = instance
+
+                changes = model_instance_diff(old, new)
+
+                # Log an entry only if there are changes
+                if changes:
+                    self.create_log(
+                        instance=instance,
+                        action=LogEntry.Action.UPDATE,
+                        changes=changes,
+                        **kwargs)
+
+    def log_delete(self, instance, **kwargs):
+        """Handle model deletion logging"""
+        if instance.pk is not None:
+            changes = model_instance_diff(instance, None)
+
+            self.create_log(
+                instance=instance,
+                action=LogEntry.Action.DELETE,
+                changes=changes,
+                **kwargs)
+
+    def create_log(self, action, instance, changes, **kwargs):
+        raise NotImplemented('Backend must implement a log create method')

--- a/src/auditlog/backends/logger.py
+++ b/src/auditlog/backends/logger.py
@@ -56,7 +56,7 @@ class LoggerBackend(AuditBackend):
             'changes': changes,
         }
 
-    def create_log(self, action, instance, changes, **kwargs):
+    def create_log_entry(self, action, instance, changes, **kwargs):
         """Generates a log entry for the given action and instance"""
         logger = self.get_logger()
         extra = self.get_extra(action, instance, changes)

--- a/src/auditlog/backends/logger.py
+++ b/src/auditlog/backends/logger.py
@@ -1,0 +1,64 @@
+import logging
+
+from django.contrib.contenttypes.models import ContentType
+from django.utils.encoding import smart_text
+
+from auditlog import settings
+from auditlog.models import LogEntry
+from auditlog.backends.base import AuditBackend
+from auditlog.middleware import get_thread_data
+
+
+class LoggerBackend(AuditBackend):
+    """Python logger based backend for creation of audit log entries."""
+    message = '{action} on {content_type_name} {object_pk} by actor {actor_name}'
+    logger = 'audit.log'
+
+    def get_level(self):
+        """Returns the level """
+        return settings.AUDITLOG_LEVEL
+
+    def get_logger(self):
+        """Returns an the python logger for logging audit messages"""
+        return logging.getLogger(settings.AUDITLOG_LOGGER)
+
+    def get_extra(self, action, instance, changes):
+        """Returns a dictionary of extra data to be passed to the logger"""
+
+        object_pk = LogEntry.objects._get_pk_value(instance)
+
+        if changes is not None:
+            get_additional_data = getattr(instance, 'get_additional_data', None)
+            content_type_name = ContentType.objects.get_for_model(instance).name
+            object_repr = smart_text(instance)
+            additional_data = get_additional_data() if callable(get_additional_data) else None
+
+        else:
+            additional_data = None
+            content_type_name = None
+            object_repr = None
+
+        thread_data = get_thread_data()
+
+        actor_pk = thread_data.get('actor_pk')
+        actor_name = thread_data.get('actor_name')
+        remote_addr = thread_data.get('remote_addr')
+
+        return {
+            'action': str(LogEntry.Action.text(action)),
+            'actor_pk': actor_pk,
+            'actor_name': actor_name,
+            'remote_addr': remote_addr,
+            'object_pk': object_pk,
+            'content_type_name': content_type_name,
+            'object_repr': object_repr,
+            'additional_data': additional_data,
+            'changes': changes,
+        }
+
+    def create_log(self, action, instance, changes, **kwargs):
+        """Generates a log entry for the given action and instance"""
+        logger = self.get_logger()
+        extra = self.get_extra(action, instance, changes)
+        message = self.message.format(**extra)
+        logger.log(level=self.get_level(), msg=message, extra=extra)

--- a/src/auditlog/backends/model.py
+++ b/src/auditlog/backends/model.py
@@ -1,0 +1,17 @@
+import json
+
+from auditlog.models import LogEntry
+
+from .base import AuditBackend
+
+
+class ModelBackend(AuditBackend):
+    """Model based backend for creation of audit log entries."""
+
+    def create_log(self, action, instance, changes, **kwargs):
+        """Creates a new LogEntry model instance for the given action and instance"""
+        return LogEntry.objects.log_create(
+            instance=instance,
+            action=action,
+            changes=json.dumps(changes),
+            **kwargs)

--- a/src/auditlog/backends/model.py
+++ b/src/auditlog/backends/model.py
@@ -8,7 +8,7 @@ from .base import AuditBackend
 class ModelBackend(AuditBackend):
     """Model based backend for creation of audit log entries."""
 
-    def create_log(self, action, instance, changes, **kwargs):
+    def create_log_entry(self, action, instance, changes, **kwargs):
         """Creates a new LogEntry model instance for the given action and instance"""
         return LogEntry.objects.log_create(
             instance=instance,

--- a/src/auditlog/models.py
+++ b/src/auditlog/models.py
@@ -171,6 +171,10 @@ class LogEntry(models.Model):
             (DELETE, _("delete")),
         )
 
+        @classmethod
+        def text(cls, value):
+            return dict(cls.choices).get(value)
+
     content_type = models.ForeignKey(to='contenttypes.ContentType', on_delete=models.CASCADE, related_name='+', verbose_name=_("content type"))
     object_pk = models.CharField(db_index=True, max_length=255, verbose_name=_("object pk"))
     object_id = models.BigIntegerField(blank=True, db_index=True, null=True, verbose_name=_("object id"))

--- a/src/auditlog/receivers.py
+++ b/src/auditlog/receivers.py
@@ -1,9 +1,6 @@
 from __future__ import unicode_literals
 
-import json
-
-from auditlog.diff import model_instance_diff
-from auditlog.models import LogEntry
+from auditlog.backends import auditlog_backend
 
 
 def log_create(sender, instance, created, **kwargs):
@@ -12,14 +9,7 @@ def log_create(sender, instance, created, **kwargs):
 
     Direct use is discouraged, connect your model through :py:func:`auditlog.registry.register` instead.
     """
-    if created:
-        changes = model_instance_diff(None, instance)
-
-        log_entry = LogEntry.objects.log_create(
-            instance,
-            action=LogEntry.Action.CREATE,
-            changes=json.dumps(changes),
-        )
+    auditlog_backend.log_create(instance, created)
 
 
 def log_update(sender, instance, **kwargs):
@@ -28,23 +18,7 @@ def log_update(sender, instance, **kwargs):
 
     Direct use is discouraged, connect your model through :py:func:`auditlog.registry.register` instead.
     """
-    if instance.pk is not None:
-        try:
-            old = sender.objects.get(pk=instance.pk)
-        except sender.DoesNotExist:
-            pass
-        else:
-            new = instance
-
-            changes = model_instance_diff(old, new)
-
-            # Log an entry only if there are changes
-            if changes:
-                log_entry = LogEntry.objects.log_create(
-                    instance,
-                    action=LogEntry.Action.UPDATE,
-                    changes=json.dumps(changes),
-                )
+    auditlog_backend.log_update(instance)
 
 
 def log_delete(sender, instance, **kwargs):
@@ -53,11 +27,4 @@ def log_delete(sender, instance, **kwargs):
 
     Direct use is discouraged, connect your model through :py:func:`auditlog.registry.register` instead.
     """
-    if instance.pk is not None:
-        changes = model_instance_diff(instance, None)
-
-        log_entry = LogEntry.objects.log_create(
-            instance,
-            action=LogEntry.Action.DELETE,
-            changes=json.dumps(changes),
-        )
+    auditlog_backend.log_delete(instance)

--- a/src/auditlog/settings.py
+++ b/src/auditlog/settings.py
@@ -1,0 +1,14 @@
+import logging
+
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+
+AUDITLOG_BACKEND = getattr(settings, 'AUDITLOG_BACKEND', 'auditlog.backends.model.ModelBackend')
+AUDITLOG_LOGGER = getattr(settings, 'AUDITLOG_LOGGER', 'audit.log')
+AUDITLOG_LEVEL = getattr(settings, 'AUDITLOG_LEVEL', logging.INFO)
+
+
+try:
+    import auditlog.backends
+except ImportError:
+    raise ImproperlyConfigured('Invalid value for AUDITLOG_BACKEND.  Please specify a valid backend.')

--- a/src/auditlog_tests/test_settings.py
+++ b/src/auditlog_tests/test_settings.py
@@ -69,3 +69,4 @@ TEMPLATES = [
 ROOT_URLCONF = 'auditlog_tests.urls'
 
 USE_TZ = True
+

--- a/src/auditlog_tests/tests.py
+++ b/src/auditlog_tests/tests.py
@@ -2,7 +2,8 @@ import datetime
 import logging
 
 try:
-    from unittest.mock import Mock, create_autospec, ANY
+    from unittest.mock import Mock, create_
+    autospec, ANY
 except ImportError:
     from mock import Mock, create_autospec, ANY
 


### PR DESCRIPTION
Backends are now configurable in settings.

This enables the sending of logs directly to a configured python logger, avoiding database bloat when there are lots of modifications.  The default settings should leave everything existing untouched (defaults to ModelBackend), but we can now configure a logger backend to direct auditlogs to a configured logger.

I haven't included a log formatter, as that is up to the end user to decide how they want to format them (we'll be doing JSON, to be consumed by our ELK stack).   All of the audit metadata gets dumped into the logs `extra` for ease of extraction when formatting a log entry.

I've had to leverage a bit more data in thread storage as I didn't want to make another trip to the database to fetch the actor details when performing the audit logging.  Felt a little bad but let me know what you think.