### PR TITLE
Corrected the issue when audit log when using django Django==2.0.1

### DIFF
--- a/src/auditlog/mixins.py
+++ b/src/auditlog/mixins.py
@@ -68,7 +68,7 @@ class LogEntryAdminMixin(object):
             value = [i, field] + (['***', '***'] if field == 'password' else changes[field])
             msg += '<tr><td>%s</td><td>%s</td><td>%s</td><td>%s</td></tr>' % tuple(value)
         msg += '</table>'
-        mark_safe(msg)
+        msg = mark_safe(msg)
         return msg
     msg.allow_tags = True
     msg.short_description = 'Changes'

--- a/src/auditlog/mixins.py
+++ b/src/auditlog/mixins.py
@@ -9,6 +9,7 @@ try:
     from django.urls.exceptions import NoReverseMatch
 except ImportError:
     from django.core.urlresolvers import NoReverseMatch
+from django.utils.safestring import mark_safe
 
 MAX = 75
 
@@ -67,6 +68,7 @@ class LogEntryAdminMixin(object):
             value = [i, field] + (['***', '***'] if field == 'password' else changes[field])
             msg += '<tr><td>%s</td><td>%s</td><td>%s</td><td>%s</td></tr>' % tuple(value)
         msg += '</table>'
+        mark_safe(msg)
         return msg
     msg.allow_tags = True
     msg.short_description = 'Changes'


### PR DESCRIPTION
When I used Django-auditlog with Django==2.0.1, field "msg" was not rendered as HTML. Instead, it was showing as plain text. So I used "mark_safe" where the HTML was generated, which fixed the issue.