### PR TITLE
fix(admin): do not show 'add' button in admin ui

### DIFF
--- a/src/auditlog/admin.py
+++ b/src/auditlog/admin.py
@@ -14,5 +14,8 @@ class LogEntryAdmin(admin.ModelAdmin, LogEntryAdminMixin):
         ('Changes', {'fields': ['action', 'msg']}),
     ]
 
+    def has_add_permission(self, request):
+        # As audit admin doesn't allow log creation from admin
+        return False
 
 admin.site.register(LogEntry, LogEntryAdmin)


### PR DESCRIPTION
This PR removes the log creation ability, along with 'add' button from being displayed in django admin for all the users.