### PR TITLE
Issue 162 - Update python-dateutil dependency version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 django-jsonfield>=1.0.0
-python-dateutil==2.6.0
+python-dateutil>=2.6.0,<2.8

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     description='Audit log app for Django',
     install_requires=[
         'django-jsonfield>=1.0.0',
-        'python-dateutil==2.6.0'
+        'python-dateutil>=2.6.0,<2.8'
     ],
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
I actually have a conflict with another package that depends on python-dateutil 2.7 hence upp'ing the max version to 2.8 😄 