### PR TITLE
Fix/better handling of deprecated functionality

### DIFF
--- a/src/auditlog/compat.py
+++ b/src/auditlog/compat.py
@@ -1,5 +1,10 @@
 import django
-from django.utils.deprecation import CallableFalse, CallableTrue
+
+try:
+    from django.utils.deprecation import CallableFalse, CallableTrue
+except ImportError:
+    CallableFalse = False
+    CallableTrue = True
 
 
 def is_authenticated(user):

--- a/src/auditlog/compat.py
+++ b/src/auditlog/compat.py
@@ -1,4 +1,6 @@
 import django
+from django.utils.deprecation import CallableFalse, CallableTrue
+
 
 def is_authenticated(user):
     """Return whether or not a User is authenticated.
@@ -10,8 +12,13 @@ def is_authenticated(user):
     as `is_authenticated` was introduced as a property in v1.10.s
     """
     if not hasattr(user, 'is_authenticated'):
-       return False
-    if callable(user.is_authenticated):
+        return False
+    if django.VERSION < (1, 10) or user.is_authenticated not in (CallableFalse, CallableTrue):
+        # Only call it as a callable if necessary (f.x. if version < 1.10 it is
+        # not a property, and in higher versions if it has been overridden as a
+        # method in an app that is not yet fully compliant with the property
+        # approach).
+        #
         # Will be callable if django.version < 2.0, but is only necessary in
         # v1.9 and earlier due to change introduced in v1.10 making
         # `is_authenticated` a property instead of a callable.

--- a/src/auditlog/diff.py
+++ b/src/auditlog/diff.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+import django
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Model, NOT_PROVIDED, DateTimeField
@@ -28,7 +29,7 @@ def track_field(field):
         return False
 
     # 1.8 check
-    elif getattr(field, 'rel', None) is not None and field.rel.to == LogEntry:
+    elif django.VERSION < (1, 9) and getattr(field, 'rel', None) is not None and field.rel.to == LogEntry:
         return False
 
     return True


### PR DESCRIPTION
Currently the code is compatible with newer versions of Django with support back to 1.8; however, unit tests that trigger some functionality in django-auditlog cause Django to fire deprecation warnings, which can impact build systems that treat warnings as errors. This PR changes the approach to diff determination and the compat version of `is_authenticated()` to prevent these warnings from happening.