### PR TITLE
Updated tests to support latest versions of Django and Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,23 +9,6 @@ services:
 addons:
   postgresql: "10"
 
-env:
-  - TOX_ENV=py36-django-18
-  - TOX_ENV=py35-django-18
-  - TOX_ENV=py34-django-18
-  - TOX_ENV=py27-django-18
-  - TOX_ENV=py36-django-110
-  - TOX_ENV=py35-django-110
-  - TOX_ENV=py34-django-110
-  - TOX_ENV=py27-django-110
-  - TOX_ENV=py36-django-111
-  - TOX_ENV=py35-django-111
-  - TOX_ENV=py34-django-111
-  - TOX_ENV=py27-django-111
-  - TOX_ENV=py36-django-20
-  - TOX_ENV=py35-django-20
-  - TOX_ENV=py34-django-20
-
 matrix:
   include:
     - python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,13 @@
 # Config file for automatic testing at travis-ci.org
 
-dist: trusty
+dist: xenial
 sudo: required
 language: python
-python: 3.6
-group: deprecated-2017Q3
 services:
   - postgresql
 
 addons:
-  postgresql: "9.4"
+  postgresql: "10"
 
 env:
   - TOX_ENV=py36-django-18
@@ -29,11 +27,47 @@ env:
   - TOX_ENV=py34-django-20
 
 matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=py27-django-111
+
+    - python: 3.4
+      env: TOXENV=py34-django-111
+    - python: 3.4
+      env: TOXENV=py34-django-20
+
+    - python: 3.5
+      env: TOXENV=py35-django-111
+    - python: 3.5
+      env: TOXENV=py35-django-20
+    - python: 3.5
+      env: TOXENV=py35-django-21
+    - python: 3.5
+      env: TOXENV=py35-django-22
+
+    - python: 3.6
+      env: TOXENV=py36-django-111
+    - python: 3.6
+      env: TOXENV=py36-django-20
+    - python: 3.6
+      env: TOXENV=py36-django-21
+    - python: 3.6
+      env: TOXENV=py36-django-22
+
+    - python: 3.7
+      env: TOXENV=py37-django-111
+    - python: 3.7
+      env: TOXENV=py37-django-20
+    - python: 3.7
+      env: TOXENV=py37-django-21
+    - python: 3.7
+      env: TOXENV=py37-django-22
+
   fast_finish: true
 
 install: pip install -r requirements-test.txt
 
-script: tox -e $TOX_ENV
+script: tox
 
 after_success:
   - codecov -e TOX_ENV

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'License :: OSI Approved :: MIT License',
     ],        
 )

--- a/src/auditlog_tests/router.py
+++ b/src/auditlog_tests/router.py
@@ -33,6 +33,6 @@ class PostgresRouter(object):
         Make sure the postgres app only appears in the 'postgres db'
         database.
         """
-        if model_name.startswith('postgres'):
+        if model_name and model_name.startswith('postgres'):
             return db == 'postgres'
         return None

--- a/src/auditlog_tests/tests.py
+++ b/src/auditlog_tests/tests.py
@@ -575,6 +575,7 @@ class CharfieldTextfieldModelTest(TestCase):
 
 
 class PostgresArrayFieldModelTest(TestCase):
+    databases = '__all__'
 
     def setUp(self):
         self.obj = PostgresArrayFieldModel.objects.create(

--- a/src/auditlog_tests/tests.py
+++ b/src/auditlog_tests/tests.py
@@ -582,20 +582,24 @@ class PostgresArrayFieldModelTest(TestCase):
             arrayfield=[PostgresArrayFieldModel.RED, PostgresArrayFieldModel.GREEN],
         )
 
+    @property
+    def latest_array_change(self):
+        return self.obj.history.using("postgres").latest().changes_display_dict["arrayfield"][1]
+
     def test_changes_display_dict_arrayfield(self):
-        self.assertTrue(self.obj.history.latest().changes_display_dict["arrayfield"][1] == "Red, Green",
+        self.assertTrue(self.latest_array_change == "Red, Green",
                         msg="The human readable text for the two choices, 'Red, Green' is displayed.")
         self.obj.arrayfield = [PostgresArrayFieldModel.GREEN]
         self.obj.save()
-        self.assertTrue(self.obj.history.latest().changes_display_dict["arrayfield"][1] == "Green",
+        self.assertTrue(self.latest_array_change == "Green",
                         msg="The human readable text 'Green' is displayed.")
         self.obj.arrayfield = []
         self.obj.save()
-        self.assertTrue(self.obj.history.latest().changes_display_dict["arrayfield"][1] == "",
+        self.assertTrue(self.latest_array_change == "",
                         msg="The human readable text '' is displayed.")
         self.obj.arrayfield = [PostgresArrayFieldModel.GREEN]
         self.obj.save()
-        self.assertTrue(self.obj.history.latest().changes_display_dict["arrayfield"][1] == "Green",
+        self.assertTrue(self.latest_array_change == "Green",
                         msg="The human readable text 'Green' is displayed.")
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,21 +1,22 @@
 [tox]
 envlist =
-    {py27,py34,py35,py36}-django-18
-    {py27,py34,py35,py36}-django-110
-    {py27,py34,py35,py36}-django-111
-    {py34,py35,py36}-django-20
+    {py27,py34,py35,py36,py37}-django-111
+    {py34,py35,py36,py37}-django-20
+    {py35,py36,py37}-django-21
+    {py35,py36,py37}-django-22
 
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/src/auditlog
 commands = coverage run --source src/auditlog src/runtests.py
 deps =
-    django-18: Django>=1.8,<1.9
-    django-110: Django>=1.10,<1.11
     django-111: Django>=1.11,<2.0
-    django-20: Django>=2.0
+    django-20: Django>=2.0,<2.1
+    django-21: Django>=2.1,<2.2
+    django-22: Django>=2.2,<2.3
     -r{toxinidir}/requirements-test.txt
 basepython =
+    py37: python3.7
     py36: python3.6
     py35: python3.5
     py34: python3.4


### PR DESCRIPTION
* Update test matrix to include all supported versions of Django and Python combinations
* Get tests to pass reliably
* Add support for Python 3.7