### PR TITLE
Added ability to define many to many relationships and register them

### DIFF
--- a/src/auditlog/migrations/0008_action_choices.py
+++ b/src/auditlog/migrations/0008_action_choices.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('auditlog', '0007_object_pk_type'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='logentry',
+            name='action',
+            field=models.PositiveSmallIntegerField(verbose_name='action', choices=[(0, 'create'), (1, 'update'), (2, 'delete'), (3, 'added')]),
+        ),
+    ]

--- a/src/auditlog/registry.py
+++ b/src/auditlog/registry.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from django.db.models.signals import pre_save, post_save, post_delete
+from django.db.models.signals import pre_save, post_save, post_delete, m2m_changed
 from django.db.models import Model
 from django.utils.six import iteritems
 
@@ -9,8 +9,8 @@ class AuditlogModelRegistry(object):
     """
     A registry that keeps track of the models that use Auditlog to track changes.
     """
-    def __init__(self, create=True, update=True, delete=True, custom=None):
-        from auditlog.receivers import log_create, log_update, log_delete
+    def __init__(self, create=True, update=True, delete=True, m2m=True, custom=None):
+        from auditlog.receivers import log_create, log_update, log_delete, log_m2m_changes
 
         self._registry = {}
         self._signals = {}
@@ -21,11 +21,13 @@ class AuditlogModelRegistry(object):
             self._signals[pre_save] = log_update
         if delete:
             self._signals[post_delete] = log_delete
+        if m2m:
+            self._signals[m2m_changed] = log_m2m_changes
 
         if custom is not None:
             self._signals.update(custom)
 
-    def register(self, model=None, include_fields=[], exclude_fields=[], mapping_fields={}):
+    def register(self, model=None, include_fields=[], exclude_fields=[], mapping_fields={}, m2m_fields={}):
         """
         Register a model with auditlog. Auditlog will then track mutations on this model's instances.
 
@@ -35,6 +37,9 @@ class AuditlogModelRegistry(object):
         :type include_fields: list
         :param exclude_fields: The fields to exclude. Overrides the fields to include.
         :type exclude_fields: list
+        :param m2m_fields: The fields to map as many to many.
+        :type m2m_fields: dict of key: list pairs
+
         """
         def registrar(cls):
             """Register models for a given class."""
@@ -45,6 +50,7 @@ class AuditlogModelRegistry(object):
                 'include_fields': include_fields,
                 'exclude_fields': exclude_fields,
                 'mapping_fields': mapping_fields,
+                'm2m_fields': m2m_fields
             }
             self._connect_signals(cls)
 
@@ -92,7 +98,28 @@ class AuditlogModelRegistry(object):
         """
         for signal in self._signals:
             receiver = self._signals[signal]
-            signal.connect(receiver, sender=model, dispatch_uid=self._dispatch_uid(signal, model))
+
+            if signal is m2m_changed:
+                # Connect Many to many signals
+                for m2m_field, m2m_signals in self._registry[model]['m2m_fields'].items():
+                    assert isinstance(m2m_signals, list)
+                    if m2m_signals == []:
+                        m2m_signals = 'post_add', 'post_remove', 'post_clear'
+
+                    field = getattr(model, m2m_field)
+                    m2m_model = getattr(field, 'through')
+                    if 'post_save' in m2m_signals:
+                        post_save_receiver = self._signals[post_save]
+                        post_save.connect(post_save_receiver, sender=m2m_model, dispatch_uid=self._dispatch_uid(m2m_model, model))
+
+                    if 'pre_save' in m2m_signals:
+                        pre_save_receiver = self._signals[pre_save]
+                        pre_save.connect(pre_save_receiver, sender=m2m_model, dispatch_uid=self._dispatch_uid(m2m_model, model))
+
+                    setattr(m2m_model, '_map_signals', m2m_signals)
+                    signal.connect(receiver, sender=m2m_model, dispatch_uid=self._dispatch_uid(signal, m2m_model))
+            else:
+                signal.connect(receiver, sender=model, dispatch_uid=self._dispatch_uid(signal, model))
 
     def _disconnect_signals(self, model):
         """


### PR DESCRIPTION
Added ability to define many to many relationships and register them in auditlog with new signal and log creator as the default implementation does not connect post_add, post_remove and post_clear actions from m2m_changed django signal.