### PR TITLE
Fix for Issue #260

### DIFF
--- a/src/auditlog/diff.py
+++ b/src/auditlog/diff.py
@@ -78,7 +78,8 @@ def get_field_value(obj, field):
         # DecimalFields can be stored with multiple zeroes after decimal but 
         # might only have one zero after save() method, so we need to remove 
         # all extra zeroes for an accurate comparison.
-        value = smart_text(getattr(obj, field.name, None)).rstrip('0').rstrip('.')
+        value_before_clean = smart_text(getattr(obj, field.name, None))
+        value = value_before_clean.rstrip('0').rstrip('.') if '.' in value_before_clean else value_before_clean
     else:
         try:
             value = smart_text(getattr(obj, field.name, None))


### PR DESCRIPTION
This is my first pull request. I hope this can help. Please let me know if you have any questions or better ideas on how to fix this.

EXAMPLE ISSUE: The field's decimal places = 2. So the db stores .00. But in the model's save() method performs calculations on that field which result in python truncating the zeros to .0. This causes model_instance_diff() to incorrectly detect a change.

THE FIX:  check if the field is a DecimalField. If so then remove all trailing zeros and the decimal. Used the code from this answer https://stackoverflow.com/questions/11227620/drop-trailing-zeros-from-decimal